### PR TITLE
more robust name handling, fix script

### DIFF
--- a/uboot/cli_mkimg.py
+++ b/uboot/cli_mkimg.py
@@ -191,7 +191,7 @@ def extract(file):
             n = 0
             for simg in img:
                 with open(os.path.join(dest_dir, 'image_{0:02d}.bin'.format(n)), 'wb') as f:
-                    f.write(simg.eport())
+                    f.write(simg.export())
                 n += 1
         elif img.header.image_type == uboot.EnumImageType.SCRIPT:
             with open(os.path.join(dest_dir, 'script.txt'), 'w') as f:


### PR DESCRIPTION
This PR has :
- fix for a script which had `eport` instead of `export` 
- fix for name handling where there are weird characters that should be ignored.
- added enhancement where we can specify that we want to ignore CRC checks

Added two unit tests for the changes I made. It looks like the tests for the script files don't work on my system.:
```
PytestUnknownMarkWarning: Unknown pytest.mark.script_launch_mode - is this a typo?  You can register custom marks to avoid this warning - for details, see
```

Looks like a missing `pytest.ini` file.
