### PR TITLE
Handle 0xff inputs and outputs and remove zlib dependency

### DIFF
--- a/uboot/env_blob.py
+++ b/uboot/env_blob.py
@@ -163,7 +163,7 @@ class EnvBlob(object):
         if read_crc != calc_crc:
             raise ValueError("Wrong CRC")
 
-        read_data = read_data.decode('utf-8')
+        read_data = read_data.decode('utf-8', errors='ignore')
 
         for s in read_data.split('\0'):
             if not s or s.startswith('\xFF') or s.startswith('\x00'):
@@ -192,9 +192,8 @@ class EnvBlob(object):
 
         if len(data) > env_size:
             raise Exception("ERROR: ENV size out of range, extend required size !")
-
-        env_blob = data + chr(self._empty_value) * (env_size - len(data))
-        env_blob = env_blob.encode('utf-8')
+        env_blob = data.encode('utf-8')
+        env_blob += self._empty_value.to_bytes(1,'little') * (env_size - len(data))
         crc = binascii.crc32(env_blob) & 0xffffffff
 
         fmt = ">I" if self._bigendian else "<I"

--- a/uboot/old_image.py
+++ b/uboot/old_image.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-import zlib
+import binascii
 from struct import pack, unpack_from, calcsize
 
 from .common import EnumArchType, EnumOsType, EnumImageType, EnumCompressionType
@@ -27,7 +27,7 @@ def CRC32(data):
     :param data: Tha data blob as byte array
     :return: CRC Value
     """
-    return zlib.crc32(data) & 0xFFFFFFFF
+    return binascii.crc32(data) & 0xFFFFFFFF
 # ----------------------------------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
I'm using this on a device with NOR flash that erases to 0xFF. The default padding of 0x00 is suboptimal because it requires writing even the empty bytes. Additionally, the whole thing throws an error on utf-8 when reading my env. Patched to gracefully handle env's padded with UTF-8

I also got rid of the dependency in old_image on zlib.